### PR TITLE
Fix compatibility with gymnasium >= 1.0.0

### DIFF
--- a/gym_xarm/tasks/base.py
+++ b/gym_xarm/tasks/base.py
@@ -19,6 +19,7 @@ elif os.environ.get("MUJOCO_GL") not in _ALL_RENDERERS:
 # so we detect the gymnasium version used to use the appropriate API
 _GYM_IS_HIGHER_OR_EQUAL_1_0_0 = not gym.__version__.startswith("0.")
 
+
 class Base(gym.Env):
     """
     Superclass for all gym-xarm environments.
@@ -158,7 +159,9 @@ class Base(gym.Env):
             else:
                 renderer_width = self.visualization_width
                 renderer_height = self.visualization_height
-            return MujocoRenderer(model, self.data, camera_name="camera0", width=renderer_width, height=renderer_height)
+            return MujocoRenderer(
+                model, self.data, camera_name="camera0", width=renderer_width, height=renderer_height
+            )
         else:
             return MujocoRenderer(model, self.data)
 

--- a/gym_xarm/tasks/base.py
+++ b/gym_xarm/tasks/base.py
@@ -14,6 +14,10 @@ if os.environ.get("MUJOCO_GL") == "glfw":
 elif os.environ.get("MUJOCO_GL") not in _ALL_RENDERERS:
     os.environ["MUJOCO_GL"] = "egl"
 
+# The MujocoRenderer API changed in gymnasium v1.0.0,
+# see https://github.com/Farama-Foundation/Gymnasium/pull/868,
+# so we detect the gymnasium version used to use the appropriate API
+_GYM_IS_HIGHER_OR_EQUAL_1_0_0 = not gym.__version__.startswith("0.")
 
 class Base(gym.Env):
     """
@@ -147,7 +151,16 @@ class Base(gym.Env):
                 f"Unknown render type {renderer_type}. Must be one of [observation, visualization]"
             )
 
-        return MujocoRenderer(model, self.data)
+        if _GYM_IS_HIGHER_OR_EQUAL_1_0_0:
+            if renderer_type == "observation":
+                renderer_width = self.observation_width
+                renderer_height = self.observation_height
+            else:
+                renderer_width = self.visualization_width
+                renderer_height = self.visualization_height
+            return MujocoRenderer(model, self.data, camera_name="camera0", width=renderer_width, height=renderer_height)
+        else:
+            return MujocoRenderer(model, self.data)
 
     @property
     def dt(self):
@@ -317,7 +330,10 @@ class Base(gym.Env):
 
     def _render(self, renderer: MujocoRenderer):
         self._render_callback()
-        render = renderer.render(self.render_mode, camera_name="camera0")
+        if _GYM_IS_HIGHER_OR_EQUAL_1_0_0:
+            render = renderer.render(self.render_mode)
+        else:
+            render = renderer.render(self.render_mode, camera_name="camera0")
         return render.copy() if render is not None else None
 
     def _render_callback(self):


### PR DESCRIPTION
The change in https://github.com/Farama-Foundation/Gymnasium/pull/868 broke the code in gym-xarm, resulting in the error:

> TypeError: MujocoRenderer.render() got an unexpected keyword argument 'camera_name' 

when executed.

This PR fixes the problem, by keeping compatibility with gymnasium 0.29.1 .

Fix https://github.com/huggingface/gym-xarm/issues/9 .
Fix https://github.com/huggingface/lerobot/issues/474 .