### PR TITLE
Relax mujoco dependency to allow mujoco 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [{include = "gym_xarm"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-mujoco = "^2.3.7"
+mujoco = ">=2.3.7"
 gymnasium = ">=0.29.1"
 gymnasium-robotics = ">=1.2.4"
 pre-commit = {version = ">=3.7.0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [{include = "gym_xarm"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-mujoco = ">=2.3.7"
+mujoco = ">=2.3.7,,<4.0.0"
 gymnasium = ">=0.29.1"
 gymnasium-robotics = ">=1.2.4"
 pre-commit = {version = ">=3.7.0", optional = true}


### PR DESCRIPTION
I tried recent mujoco versions, and 3.* versions work fine. For this reason, I relax the dependency, keeping anyhow the upper bound to not be compatible with future mujoco 4.0.0 .